### PR TITLE
Speed up shape_key_apply_modifiers using buffers

### DIFF
--- a/mesh/shape_key_apply_modifiers.py
+++ b/mesh/shape_key_apply_modifiers.py
@@ -1,4 +1,5 @@
 from collections import namedtuple, defaultdict
+import numpy as np
 import bmesh
 import bpy
 
@@ -19,7 +20,7 @@ class ShapeKeyInfo(namedtuple('ShapeKeyInfo', ['coords', 'interpolation', 'mute'
     @classmethod
     def from_shape_key_with_empty_data(cls, shape_key):
         return cls(
-            coords=[],
+            coords=np.empty(0, dtype=np.single),
             interpolation=shape_key.interpolation,
             mute=shape_key.mute,
             name=shape_key.name,
@@ -37,7 +38,7 @@ class ShapeKeyInfo(namedtuple('ShapeKeyInfo', ['coords', 'interpolation', 'mute'
         return info
 
     def get_coords_from(self, vertices):
-        self.coords[:] = [0.0] * (len(vertices) * 3)
+        self.coords.resize(len(vertices) * 3, refcheck=False)
         vertices.foreach_get('co', self.coords)
 
     def put_coords_into(self, vertices):


### PR DESCRIPTION
By using buffer objects with type matching the 'co' data (single precision float), in foreach_set and foreach_get, Blender will directly memcpy the data into/out of the buffer instead of iterating and casting each element to the correct type. This results in slightly faster foreach_set and foreach_get calls.

It's probably not much of a timesave unless the mesh being operated on is huge (or ends up huge from its modifiers) and/or has a ton of shape keys.

Here's the foreach_getset code in Blender's source: https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/python/intern/bpy_rna.c#L5228
The lines containing `!buffer_is_compat` are where it'll swap to iteration if the buffer isn't compatible with the data, the code for compatible buffers is right before.

Here's the code I used for benchmarking along with results in the comments:
```py
import bpy
import numpy as np
import timeit

# Requirements:
# In object mode with an active mesh object in current scene that has shape keys


def orig_get(my_list, vertices):
    my_list[:] = [0.0] * (len(vertices) * 3)
    vertices.foreach_get('co', my_list)

def np_get(my_array, vertices):
    my_array.resize(len(vertices) * 3, refcheck=False)
    vertices.foreach_get('co', my_array)
    
def put(my_list_or_array, vertices):
    vertices.foreach_set('co', my_list_or_array)
    

trials = 1000


get_setup = "basis=bpy.context.object.data.shape_keys.key_blocks[0]"
put_setup_orig = get_setup + ";my_list = [];orig_get(my_list, basis.data)"
put_setup_np = get_setup + ";my_array = np.empty(0, dtype=np.single);np_get(my_array, basis.data)"

# ~56.49ms per call with 393218 verts (ran with 100 trials instead of 1000)
# ~2.96ms per call with 24578 verts
# ~0.041ms per call with 386 verts
print(timeit.timeit("my_list = [];orig_get(my_list, basis.data)", setup=get_setup, globals=globals(), number=trials)/trials*1000)
# ~18.82ms per call with 393218 verts (ran with 100 trials instead of 1000) (3x)
# ~1.16ms per call with 24578 verts (2.55x)
# ~0.022ms per call with 386 verts (1.86x)
print(timeit.timeit("my_array = np.empty(0, dtype=np.single);np_get(my_array, basis.data)", setup=get_setup, globals=globals(), number=trials)/trials*1000)

# ~28.45ms per call with 393218 verts (ran with 100 trials instead of 1000)
# ~1.75ms per call with 24578 verts
# ~0.03ms per call with 386 verts
print(timeit.timeit("put(my_list, basis.data)", setup=put_setup_orig, globals=globals(), number=trials)/trials*1000)
# ~20.85ms per call with 393218 verts (ran with 100 trials instead of 1000) (1.36x)
# ~1.29ms per call with 24578 verts (1.36x)
# ~0.022ms per call with 386 verts (1.36x)
print(timeit.timeit("put(my_array, basis.data)", setup=put_setup_np, globals=globals(), number=trials)/trials*1000)```