### PR TITLE
Fix 4.1 by removing 2D_ prefix

### DIFF
--- a/drawing.py
+++ b/drawing.py
@@ -7,8 +7,8 @@ import bpy
 import gpu
 import numpy as np
 
-shader_image = gpu.shader.from_builtin('2D_IMAGE')
-shader_solid = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+shader_image = gpu.shader.from_builtin('IMAGE')
+shader_solid = gpu.shader.from_builtin('UNIFORM_COLOR')
 shader_image_alpha = gpu.types.GPUShader("""
 uniform mat4 ModelViewProjectionMatrix;
 /* Keep in sync with intern/opencolorio/gpu_shader_display_transform_vertex.glsl */


### PR DESCRIPTION
Tiny fix to allow loading in 4.1-ALPHA, but should work all the way down to 3.4
Appears that this was changed between versions [3.3](https://docs.blender.org/api/3.3/gpu.shader.html) to [3.4](https://docs.blender.org/api/3.4/gpu.shader.html) although I cannot find the exact commit or details.