### PR TITLE
Decimate with Shapekeys support

### DIFF
--- a/mesh/shape_key_apply_modifiers.py
+++ b/mesh/shape_key_apply_modifiers.py
@@ -194,7 +194,6 @@ class DecimateModifierHandler(ModifierHandler):
         return super().poll(modifier) and modifier.decimate_type == "COLLAPSE"
 
     def apply(self, obj):
-        print("wow")
         modifier = obj.modifiers[self.modifier_name]
         # There are special EDIT modes depending on object type, but mode_set only accepts EDIT.
         mode = bpy.context.mode if not bpy.context.mode.count('EDIT') else 'EDIT'

--- a/mesh/shape_key_apply_modifiers.py
+++ b/mesh/shape_key_apply_modifiers.py
@@ -202,7 +202,7 @@ class DecimateModifierHandler(ModifierHandler):
         shapekey_index = obj.active_shape_key_index
 
         obj.active_shape_key_index = 0
-        if self.vertex_group:
+        if self.vertex_group and obj.vertex_groups.get(self.vertex_group):
             obj.vertex_groups.active_index = obj.vertex_groups.get(self.vertex_group).index
 
         # Makes sure everything is deselected first.
@@ -394,7 +394,7 @@ class GRET_OT_shape_key_apply_modifiers(bpy.types.Operator):
                         modifier_handler = modifier_handler_cls(modifier)
 
                         # Hardcoded. if more special handlers are added later a bool check in the Handler class would be better
-                        if modifier_handler.modifier_name == "Decimate":
+                        if modifier_handler.modifier_type == "DECIMATE":
                             post_modifier_handlers.append(modifier_handler)
                             break
 


### PR DESCRIPTION
This adds proper support for decimation with shapekeys through a modifier handler that is applied after the standard process. It uses an decimate operator instead of the modifier, which works identically but keeps the shapekeys without breaking them.

The only caveat is that it only works with collapse, so unsubdivide and planar decimation are not supported since there is no operator for them as far as i'm aware.

Thanks greisane for this great plugin! Would be nice to see you post content on Twitter again! 

I've never merged before so let me know if i messed something up.