### PR TITLE
Decimate with Shapekey Support

### DIFF
--- a/mesh/shape_key_apply_modifiers.py
+++ b/mesh/shape_key_apply_modifiers.py
@@ -67,6 +67,7 @@ class ModifierHandler:
 
     modifier_type = None
     modifier_name = None
+    apply_post = False
 
     def __init__(self, modifier):
         self.modifier_name = modifier.name
@@ -176,9 +177,62 @@ class WeldModifierHandler(ModifierHandler):
         self.weld_map = {src.index: dst.index for src, dst in targetmap.items()}
         bm.free()
 
+class DecimateModifierHandler(ModifierHandler):
+    # Only works with "collapse" decimate type. There are no operators for the other types as far as i'm aware.
+    modifier_type = "DECIMATE"
+    # Since an operator exists that preserves all shapekeys, it's applied after every other operation a single time.
+    apply_post = True
+
+    def __init__(self, modifier):
+        super().__init__(modifier)
+        self.ratio = modifier.ratio
+        self.vertex_group = modifier.vertex_group
+        self.invert_vertex_group = modifier.invert_vertex_group
+        self.vertex_group_factor = modifier.vertex_group_factor
+        self.use_symmetry = modifier.use_symmetry
+        self.symmetry_axis = modifier.symmetry_axis
+
+    @classmethod
+    def poll(cls, modifier):
+        return super().poll(modifier) and modifier.decimate_type == "COLLAPSE"
+
+    def apply(self, obj):
+        modifier = obj.modifiers[self.modifier_name]
+        # There are special EDIT modes depending on object type, but mode_set only accepts EDIT.
+        mode = bpy.context.mode if not bpy.context.mode.count('EDIT') else 'EDIT'
+        active_obj = bpy.context.view_layer.objects.active
+        selected_objs = bpy.context.selected_objects
+        shapekey_index = obj.active_shape_key_index
+
+        obj.active_shape_key_index = 0
+        if self.vertex_group and obj.vertex_groups.get(self.vertex_group):
+            obj.vertex_groups.active_index = obj.vertex_groups.get(self.vertex_group).index
+
+        # Makes sure everything is deselected first.
+        bpy.ops.object.mode_set(mode='OBJECT')
+        bpy.ops.object.select_all(action='DESELECT')
+
+        bpy.context.view_layer.objects.active = obj
+        bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.mesh.reveal()
+        bpy.ops.mesh.select_all(action='SELECT')
+
+        with_object(bpy.ops.mesh.decimate, obj, ratio=self.ratio, use_vertex_group=True if self.vertex_group else False, vertex_group_factor=self.vertex_group_factor, invert_vertex_group=self.invert_vertex_group, use_symmetry=self.use_symmetry, symmetry_axis=self.symmetry_axis)
+        obj.modifiers.remove(modifier)
+
+        # Reassigns the selected objects, active object and mode, as well as the active shapekey in the object.
+        obj.active_shape_key_index = shapekey_index
+        for obj in selected_objs:
+            obj.select_set(True)
+        bpy.context.view_layer.objects.active = active_obj
+        bpy.ops.object.mode_set(mode=mode)
+
+
+
 modifier_handler_classes = (
     MirrorModifierHandler,
     WeldModifierHandler,
+    DecimateModifierHandler,
     ModifierHandler,
 )
 
@@ -335,11 +389,17 @@ class GRET_OT_shape_key_apply_modifiers(bpy.types.Operator):
         # Handle modifiers accordingly. This means recording welded vertex pairs for mirrors and such
         obj.shape_key_clear()
         modifier_handlers = []
+        post_modifier_handlers = []
         for modifier, mask in zip(obj.modifiers[:], self.modifier_mask):
             if mask:
                 for modifier_handler_cls in modifier_handler_classes:
                     if modifier_handler_cls.poll(modifier):
                         modifier_handler = modifier_handler_cls(modifier)
+
+                        if modifier_handler.apply_post:
+                            post_modifier_handlers.append(modifier_handler)
+                            break
+
                         modifier_handler.apply(obj)
                         modifier_handlers.append(modifier_handler)
                         break
@@ -371,6 +431,10 @@ class GRET_OT_shape_key_apply_modifiers(bpy.types.Operator):
                     "the shape key will be lost.")
                 continue
             shape_key_info.put_coords_into(shape_key.data)
+
+        # For modifiers that should be applied after all the shapekeys are sorted.
+        for modifier_handler in post_modifier_handlers:
+            modifier_handler.apply(obj)
 
         # Recreate drivers
         if mesh_copy.shape_keys and mesh_copy.shape_keys.animation_data:


### PR DESCRIPTION
Adds a new modifier handler (Decimate) that is applied after every other process, it uses a decimate operator built into Blender which works identical to the modifier and keeps the shapekeys. The only caveat is that it only works with collapse, so unsubdivide and planar decimation are not supported since there is no operator for them as far as i'm aware.

Sorry once again for the many closed pull requests, I learned the proper way of branching and pull requests just to contribute to this plugin!