### PR TITLE
Blender 4.2/4.3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of Blender tools I've written for myself over the years. I use thes
 # Installation
 
 Blender 4.1 or later required.
+> This tool has been updated to work with blender 4.2.0 -> 4.3.2
 
 1. Download the [latest release](https://github.com/greisane/gret/releases/latest).
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,9 @@
 bl_info = {
     'name': "gret",
-    'author': "greisane",
+    'author': "greisane (& DevianDice)",
     'description': "Collection of Blender tools",
-    'version': (1, 4, 0),
-    'blender': (4, 0, 1),
+    'version': (1, 4, 2),
+    'blender': (4, 2, 0),
     'location': "3D View > Tools",
     'category': "Object",
     'doc_url': "https://github.com/greisane/gret#readme",

--- a/jobs/rig_export.py
+++ b/jobs/rig_export.py
@@ -117,11 +117,7 @@ def _rig_export(context, job, rig, save, results):
 
         # Ensure mesh has custom normals so that they won't be recalculated on masking
         with_object(bpy.ops.mesh.customdata_custom_splitnormals_add, obj)
-        if hasattr(mesh, "use_auto_smooth"):
-            mesh.use_auto_smooth = True
-            mesh.auto_smooth_angle = pi
-        else:
-            mesh.shade_smooth()
+        mesh.shade_smooth()
 
         # Remove vertex group filtering from shapekeys before merging
         apply_shape_keys_with_vertex_groups(obj)
@@ -353,14 +349,6 @@ def _rig_export(context, job, rig, save, results):
             if clean_vertex_groups:
                 for vg_index in reversed(get_operator_target_vertex_groups(obj, 'BONE_NOT_DEFORM')):
                     obj.vertex_groups.remove(obj.vertex_groups[vg_index])
-
-            # Auto-smooth has a noticeable impact in performance while animating,
-            # disable unless the user explicitly enabled it in the previous build result
-            if hasattr(obj.data, "use_auto_smooth"):
-                # Auto-smooth doesn't exist since 4.1
-                obj.data.use_auto_smooth = False
-                if old_obj and old_obj.type == 'MESH':
-                    obj.data.use_auto_smooth = old_obj.data.use_auto_smooth
 
             results.extend([obj, obj.data])
 

--- a/mesh/extra_objects.py
+++ b/mesh/extra_objects.py
@@ -281,16 +281,10 @@ class GRET_OT_rope_add(bpy.types.Operator):
         vertices.extend([Vector((v.x, v.y, cut_height)) for v in vertices])
         mesh.from_pydata(vertices, [], faces)
 
-        if hasattr(mesh, "use_auto_smooth"):
-            for face in mesh.polygons:
-                face.use_smooth = self.use_smooth_shade
-            mesh.use_auto_smooth = True
-            mesh.auto_smooth_angle = pi
+        if self.use_smooth_shade:
+            mesh.shade_smooth()
         else:
-            if self.use_smooth_shade:
-                mesh.shade_smooth()
-            else:
-                mesh.shade_flat()
+            mesh.shade_flat()
 
         crease_data = mesh.attributes.new('crease_edge', domain='EDGE', type='FLOAT').data
         for edge in (mesh.edges[4], mesh.edges[8]):

--- a/mesh/graft.py
+++ b/mesh/graft.py
@@ -129,11 +129,7 @@ def do_graft(context, save, obj, dst_obj, expand=0, cuts=0, blend_distance=0.0, 
 
     # Transfer stuff
     if copy_normals:
-        if hasattr(obj.data, "use_auto_smooth"):
-            obj.data.use_auto_smooth = True
-            obj.data.auto_smooth_angle = pi
-        else:
-            obj.data.shade_smooth()
+        obj.data.shade_smooth()
         with_object(bpy.ops.mesh.customdata_custom_splitnormals_clear, obj)
 
         with instant_modifier(obj, type='DATA_TRANSFER') as data_mod:

--- a/mesh/merge.py
+++ b/mesh/merge.py
@@ -369,11 +369,7 @@ Use to leave normals intact on hair ends and crevices""",
         clean_bm.to_mesh(dst_mesh)
 
         # Normals post-processing and transfer
-        if hasattr(dst_mesh, 'use_auto_smooth'):
-            dst_mesh.use_auto_smooth = True
-            dst_mesh.auto_smooth_angle = pi
-        else:
-            dst_mesh.shade_smooth()
+        dst_mesh.shade_smooth()
         with_object(bpy.ops.mesh.customdata_custom_splitnormals_clear, dst_obj)
 
         if self.smooth_iterations > 0 and self.smooth_mix > 0.0:


### PR DESCRIPTION
Removed references to ``use_auto_smooth`` which has been depreciated since blender 4.2, now supports 4.2-4.3.2.